### PR TITLE
use set instead of setHeader

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -143,7 +143,13 @@
         } else if (header.key === 'Vary' && header.value) {
           vary(res, header.value);
         } else if (header.value) {
-          res.setHeader(header.key, header.value);
+          if (res.set) {
+            // for Express 4+
+            res.set(header.key, header.value);
+          } else {
+            // for Express <4
+            res.setHeader(header.key, header.value);
+          }
         }
       }
     }

--- a/test/cors.js
+++ b/test/cors.js
@@ -35,6 +35,10 @@
           headers[key] = value;
           return;
         },
+        set: function (key, value) {
+          headers[key] = value;
+          return;
+        },
         get: function (key) {
           return headers[key];
         }
@@ -294,7 +298,7 @@
         };
         req = fakeRequest();
         res = fakeResponse();
-        res.setHeader('Vary', 'Foo');
+        res.set('Vary', 'Foo');
         next = function () {
           // assert
           res.getHeader('Vary').should.equal('Foo, Origin');


### PR DESCRIPTION
Not sure why setHeader is used at all. The block that was added to index.js was taken from https://github.com/expressjs/cors/commit/fee800f0dc13a1df5b696035f09c43b8c714371b. I'm not sure why it was pulled out of that file with that PR as the comment that caused that PR (https://github.com/expressjs/cors/commit/165f35e8) has nothing to do with that block.

The problem stems from this...

When you use setHeader with the mock response that Sails uses the headers that are set are set in res._headers and not res.headers, so our specs fail.
